### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
     "Import"
   ],
   "description": "Converts MOT format to Supervisely",
-  "docker_image": "supervisely/base-py-sdk:6.35.0",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "name": "Import MOT",
   "type": "app",
+  "instance_version": "6.15.60",
   "categories": [
     "Import"
   ],

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "Import"
   ],
   "description": "Converts MOT format to Supervisely",
-  "docker_image": "supervisely/base-py-sdk:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,1 @@
+supervisely==6.73.564

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.35.0
+supervisely==6.73.564

--- a/src/dl_progress.py
+++ b/src/dl_progress.py
@@ -1,4 +1,4 @@
-import supervisely_lib as sly
+import supervisely as sly
 from functools import partial
 import globals as g
 

--- a/src/globals.py
+++ b/src/globals.py
@@ -1,5 +1,5 @@
 import os, time
-import supervisely_lib as sly
+import supervisely as sly
 
 
 my_app = sly.AppService()

--- a/src/main.py
+++ b/src/main.py
@@ -3,9 +3,9 @@ import shutil
 import dl_progress
 import requests
 import globals as g
-import supervisely_lib as sly
-from supervisely_lib.annotation.tag_meta import TagValueType
-from supervisely_lib.io.fs import download, file_exists
+import supervisely as sly
+from supervisely.annotation.tag_meta import TagValueType
+from supervisely.io.fs import download, file_exists
 
 import mot_importer
 

--- a/src/mot_importer.py
+++ b/src/mot_importer.py
@@ -1,11 +1,11 @@
 import os
 import cv2
 import globals as g
-import supervisely_lib as sly
+import supervisely as sly
 from collections import defaultdict
-from supervisely_lib.io.fs import get_file_name, dir_exists
-from supervisely_lib.video_annotation.video_tag import VideoTag
-from supervisely_lib.video_annotation.video_tag_collection import VideoTagCollection
+from supervisely.io.fs import get_file_name, dir_exists
+from supervisely.video_annotation.video_tag import VideoTag
+from supervisely.video_annotation.video_tag_collection import VideoTagCollection
 
 
 def get_sl_bbox(coords, img_size):


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
